### PR TITLE
chore: pin GitHub Actions to commit SHAs [skip deploy]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,14 @@ jobs:
 
     steps:
     - name: Checkout current branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install sqlite3 on system
       run: |
         sudo apt-get install libsqlite3-dev
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler: '2.4.22'


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

This PR is part of a proactive security hardening effort across all Wealthsimple repositories.

Pinning Actions to specific commit SHAs prevents supply chain attacks where a mutable tag (e.g. `@v1`) could be silently updated to inject malicious code into CI. Each action has been upgraded to the latest release older than 5 days and pinned to its commit SHA. The original tag is preserved as an inline comment for readability.

### Pinned Actions

| Action | Tag | SHA (short) |
|--------|-----|-------------|
| `actions/checkout` | `v6.0.2` | `de0fac2e` |
| `ruby/setup-ruby` | `v1.305.0` | `0cb964fd` |

### Files Changed

- `.github/workflows/ci.yml`
---

JIRA: [PLDY-872](https://wealthsimple.atlassian.net/browse/PLDY-872)

[PLDY-872]: https://wealthsimple.atlassian.net/browse/PLDY-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ